### PR TITLE
Clarify strictness newline at end of file

### DIFF
--- a/docs/rules/header.md
+++ b/docs/rules/header.md
@@ -8,7 +8,7 @@ This rule validates the presence of a license header
 This rule aims to support you by ensuring that all files in your project
 have a uniform license header.
 
-Assuming the file `./resources/license-header.js` contains the following contents:
+Assuming the file `./resources/license-header.js` contains the following contents (no newline at the end of file):
 
 ```javascript
 /**


### PR DESCRIPTION
If you have a newline at the end of `resources/license-header.js` (in particular, a `lint-staged` commit hook might even add that depending on https://eslint.org/docs/rules/eol-last), then all license headers will look invalid, and `eslint --fix .` will add a superfluous newline between the header
and the code. Took me some time to debug that. :)