### PR TITLE
fix(rules/header): trim lead/trail whitespace

### DIFF
--- a/docs/rules/header.md
+++ b/docs/rules/header.md
@@ -8,7 +8,8 @@ This rule validates the presence of a license header
 This rule aims to support you by ensuring that all files in your project
 have a uniform license header.
 
-Assuming the file `./resources/license-header.js` contains the following contents (no newline at the end of file):
+Assuming the file `./resources/license-header.js` contains the following contents
+(whitespace such as newlines will be trimmed before and after the comment):
 
 ```javascript
 /**

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -75,7 +75,7 @@ module.exports = {
 
       const [ path ] = options;
 
-      const licenseHeader = readLicenseFile(path);
+      const licenseHeader = readLicenseFile(path).trim();
 
       return {
         licenseHeader

--- a/tests/fixtures/license-header-blank-line-at-end.js
+++ b/tests/fixtures/license-header-blank-line-at-end.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) Foo Corp.
+ *
+ * This source code is licensed under the WTFPL license found in the
+ * LICENSE file in the root of this projects source tree.
+ */

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -14,6 +14,7 @@ const { Linter, RuleTester } = require('eslint');
 
 const licenseText = fs.readFileSync(__dirname + '/../../fixtures/license-header.js', 'utf-8');
 const licensePath = 'tests/fixtures/license-header.js';
+const licensePathWithBlank = 'tests/fixtures/license-header-blank-line-at-end.js';
 
 const invalidLicenseText = licenseText.replace(' Foo Corp.', ' Fooooo Corp.');
 
@@ -32,6 +33,10 @@ ruleTester.run('header', rule, {
     {
       code: `${licenseText}\n\n/** do this */\nmodule.exports = function() {};`,
       options: [ licensePath ]
+    },
+    {
+      code: `${licenseText}\n\n/** do this */\nmodule.exports = function() {};`,
+      options: [ licensePathWithBlank ]
     },
     {
       code: `${licenseText}\n\n/** do this */\nmodule.exports = function() {};`,


### PR DESCRIPTION
Related to #5, use trim() so that trailing whitespace is corrected before test.

Closes #8