### PR TITLE
feat(rules/header): trim whitespace around parsed license header

### DIFF
--- a/docs/rules/header.md
+++ b/docs/rules/header.md
@@ -5,10 +5,9 @@ This rule validates the presence of a license header
 
 ## Rule Details
 
-This rule aims to support you by ensuring that all files in your project
-have a uniform license header.
+This rule aims to support you by ensuring that all files in your project have a uniform license header.
 
-Assuming the file `./resources/license-header.js` contains the following contents (no newline at the end of file):
+Assuming the file `./resources/license-header.js` contains the following contents (whitespace around comment will be trimmed):
 
 ```javascript
 /**

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -75,7 +75,7 @@ module.exports = {
 
       const [ path ] = options;
 
-      const licenseHeader = readLicenseFile(path);
+      const licenseHeader = readLicenseFile(path).trim();
 
       return {
         licenseHeader

--- a/tests/fixtures/license-header-whitespace.js
+++ b/tests/fixtures/license-header-whitespace.js
@@ -1,0 +1,7 @@
+
+/**
+ * Copyright (c) Foo Corp.
+ *
+ * This source code is licensed under the WTFPL license found in the
+ * LICENSE file in the root of this projects source tree.
+ */

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -14,6 +14,7 @@ const { Linter, RuleTester } = require('eslint');
 
 const licenseText = fs.readFileSync(__dirname + '/../../fixtures/license-header.js', 'utf-8');
 const licensePath = 'tests/fixtures/license-header.js';
+const licenceWhitespacePath = 'tests/fixtures/license-header-whitespace.js';
 
 const invalidLicenseText = licenseText.replace(' Foo Corp.', ' Fooooo Corp.');
 
@@ -32,6 +33,10 @@ ruleTester.run('header', rule, {
     {
       code: `${licenseText}\n\n/** do this */\nmodule.exports = function() {};`,
       options: [ licensePath ]
+    },
+    {
+      code: `${licenseText}\n\n/** do this */\nmodule.exports = function() {};`,
+      options: [ licenceWhitespacePath ]
     },
     {
       code: `${licenseText}\n\n/** do this */\nmodule.exports = function() {};`,
@@ -251,6 +256,17 @@ ruleTester.run('header', rule, {
       code: `#!/foo/bar\n\n\n${licenseTextWin}\n\nmodule.exports = function() {};`,
       output: `#!/foo/bar\n\n\n${licenseText}\n\nmodule.exports = function() {};`,
       options: [ licensePath ],
+      errors: [
+        {
+          message: 'Invalid license header',
+          type: 'Block'
+        }
+      ]
+    },
+    {
+      code: `${invalidLicenseText}\n\nmodule.exports = function() {};`,
+      output: `${licenseText}\n\nmodule.exports = function() {};`,
+      options: [ licenceWhitespacePath ],
       errors: [
         {
           message: 'Invalid license header',


### PR DESCRIPTION
Closes #5