### PR TITLE
feat(array license): add array licenses

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -71,6 +71,7 @@ module.exports = {
     }
 
     function parseOptions(context) {
+
       const {
         options
       } = context;

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -42,6 +42,7 @@ module.exports = {
 
     const licenseHeader = replaceNewlines(rawHeader, newlineChar);
 
+
     // ----------------------------------------------------------------------
     // Helpers
     // ----------------------------------------------------------------------
@@ -53,6 +54,7 @@ module.exports = {
     }
 
     function readLicenseFile(path) {
+
       if (!path) {
         throw new Error('missing license header path');
       }
@@ -69,7 +71,9 @@ module.exports = {
     }
 
     function parseOptions(context) {
-      const { options } = context;
+      const {
+        options
+      } = context;
 
       const [ pathOrLicense ] = options;
 
@@ -83,7 +87,9 @@ module.exports = {
         licenseHeader = readLicenseFile(pathOrLicense).trim();
       }
 
-      return { licenseHeader };
+      return {
+        licenseHeader
+      };
     }
 
     function isShebang(node) {

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -17,17 +17,28 @@ module.exports = {
       category: 'Possible Errors',
       recommended: true
     },
-    fixable: true
+    fixable: true,
+    schema: [
+      {
+        type: [ 'string', 'array' ],
+        items: {
+          type: 'string'
+        }
+      }
+    ]
   },
 
   create: function(context) {
+
     const sourceCode = context.getSourceCode();
 
     const newlineChar = getNewlineCharacter(sourceCode);
 
     const separator = `${newlineChar}${newlineChar}`;
 
-    const { licenseHeader: rawHeader } = parseOptions(context);
+    const {
+      licenseHeader: rawHeader
+    } = parseOptions(context);
 
     const licenseHeader = replaceNewlines(rawHeader, newlineChar);
 
@@ -38,7 +49,7 @@ module.exports = {
     function getNewlineCharacter(sourceCode) {
       const match = LINEBREAK_MATCHER.exec(sourceCode.getText());
 
-      return (match && match[0]) || '\n';
+      return match && match[0] || '\n';
     }
 
     function readLicenseFile(path) {
@@ -92,7 +103,9 @@ module.exports = {
     }
 
     function findLicenseComment(comments) {
+
       return comments.reduce(function(found, comment) {
+
         if (found !== null) {
           return found;
         }
@@ -112,6 +125,7 @@ module.exports = {
 
     return {
       Program: function(programNode) {
+
         const firstStatement = programNode.body[0];
 
         const comments = getLeadingComments(firstStatement || programNode);
@@ -131,8 +145,7 @@ module.exports = {
 
           const previousSibling = comments[comments.indexOf(licenseNode) - 1];
 
-          const nextSibling =
-						comments[comments.indexOf(licenseNode) + 1] || firstStatement;
+          const nextSibling = comments[comments.indexOf(licenseNode) + 1] || firstStatement;
 
           if (nextSibling) {
             const lLocEnd = licenseNode.loc.end.line;
@@ -163,6 +176,7 @@ module.exports = {
               });
             }
           }
+
 
           if (previousSibling) {
             const lLocStart = licenseNode.loc.start.line;
@@ -219,11 +233,10 @@ module.exports = {
                   `${separator}${licenseHeader}`
                 );
               } else {
+
                 const beforeNode = comments[0] || firstStatement;
 
-                const endRange = beforeNode
-                  ? beforeNode.range[0]
-                  : programNode.range[1];
+                const endRange = beforeNode ? beforeNode.range[0] : programNode.range[1];
 
                 return fixer.replaceTextRange(
                   [ 0, endRange ],

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -17,28 +17,19 @@ module.exports = {
       category: 'Possible Errors',
       recommended: true
     },
-    fixable: true,
-    schema: [
-      {
-        type: 'string'
-      }
-    ]
+    fixable: true
   },
 
   create: function(context) {
-
     const sourceCode = context.getSourceCode();
 
     const newlineChar = getNewlineCharacter(sourceCode);
 
     const separator = `${newlineChar}${newlineChar}`;
 
-    const {
-      licenseHeader: rawHeader
-    } = parseOptions(context);
+    const { licenseHeader: rawHeader } = parseOptions(context);
 
     const licenseHeader = replaceNewlines(rawHeader, newlineChar);
-
 
     // ----------------------------------------------------------------------
     // Helpers
@@ -47,11 +38,10 @@ module.exports = {
     function getNewlineCharacter(sourceCode) {
       const match = LINEBREAK_MATCHER.exec(sourceCode.getText());
 
-      return match && match[0] || '\n';
+      return (match && match[0]) || '\n';
     }
 
     function readLicenseFile(path) {
-
       if (!path) {
         throw new Error('missing license header path');
       }
@@ -68,18 +58,21 @@ module.exports = {
     }
 
     function parseOptions(context) {
+      const { options } = context;
 
-      const {
-        options
-      } = context;
+      const [ pathOrLicense ] = options;
 
-      const [ path ] = options;
+      let licenseHeader;
 
-      const licenseHeader = readLicenseFile(path).trim();
+      if (Array.isArray(pathOrLicense)) {
 
-      return {
-        licenseHeader
-      };
+        // If the path is an array, that means simply use each element as a line for the header
+        licenseHeader = pathOrLicense.join('\n');
+      } else {
+        licenseHeader = readLicenseFile(pathOrLicense).trim();
+      }
+
+      return { licenseHeader };
     }
 
     function isShebang(node) {
@@ -99,9 +92,7 @@ module.exports = {
     }
 
     function findLicenseComment(comments) {
-
       return comments.reduce(function(found, comment) {
-
         if (found !== null) {
           return found;
         }
@@ -121,7 +112,6 @@ module.exports = {
 
     return {
       Program: function(programNode) {
-
         const firstStatement = programNode.body[0];
 
         const comments = getLeadingComments(firstStatement || programNode);
@@ -141,7 +131,8 @@ module.exports = {
 
           const previousSibling = comments[comments.indexOf(licenseNode) - 1];
 
-          const nextSibling = comments[comments.indexOf(licenseNode) + 1] || firstStatement;
+          const nextSibling =
+						comments[comments.indexOf(licenseNode) + 1] || firstStatement;
 
           if (nextSibling) {
             const lLocEnd = licenseNode.loc.end.line;
@@ -172,7 +163,6 @@ module.exports = {
               });
             }
           }
-
 
           if (previousSibling) {
             const lLocStart = licenseNode.loc.start.line;
@@ -229,10 +219,11 @@ module.exports = {
                   `${separator}${licenseHeader}`
                 );
               } else {
-
                 const beforeNode = comments[0] || firstStatement;
 
-                const endRange = beforeNode ? beforeNode.range[0] : programNode.range[1];
+                const endRange = beforeNode
+                  ? beforeNode.range[0]
+                  : programNode.range[1];
 
                 return fixer.replaceTextRange(
                   [ 0, endRange ],

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "all": "run-s lint test:coverage",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "test:coverage": "nyc --reporter lcov --exclude \"tests/**\" mocha tests --recursive",
     "test": "mocha tests --recursive"
   },

--- a/tests/fixtures/license-header-array.js
+++ b/tests/fixtures/license-header-array.js
@@ -1,0 +1,8 @@
+module.exports = [
+  '/**',
+  ' * Copyright (c) Foo Corp.',
+  ' *',
+  ' * This source code is licensed under the WTFPL license found in the',
+  ' * LICENSE file in the root of this projects source tree.',
+  ' */'
+];

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -21,6 +21,9 @@ const invalidLicenseText = licenseText.replace(' Foo Corp.', ' Fooooo Corp.');
 const licenseTextWin = fs.readFileSync(__dirname + '/../../fixtures/license-header-win.js', 'utf-8');
 const licensePathWin = 'tests/fixtures/license-header-win.js';
 
+const arrayLicense = require('../../fixtures/license-header-array');
+const arrayLicenseText = arrayLicense.join('\n');
+
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
@@ -28,7 +31,6 @@ const licensePathWin = 'tests/fixtures/license-header-win.js';
 const ruleTester = new RuleTester();
 
 ruleTester.run('header', rule, {
-
   valid: [
     {
       code: `${licenseText}\n\n/** do this */\nmodule.exports = function() {};`,
@@ -59,8 +61,12 @@ ruleTester.run('header', rule, {
       options: [ licensePath ]
     },
     {
-      code: `${licenseText}\n\n\n\n`,
+      code: `${licenseText}\n\nmodule.exports = function() {};`,
       options: [ licensePath ]
+    },
+    {
+      code: `${arrayLicenseText}\n\nmodule.exports = function() {};`,
+      options: [ arrayLicense ]
     }
   ],
 

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -31,6 +31,7 @@ const arrayLicenseText = arrayLicense.join('\n');
 const ruleTester = new RuleTester();
 
 ruleTester.run('header', rule, {
+
   valid: [
     {
       code: `${licenseText}\n\n/** do this */\nmodule.exports = function() {};`,

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -61,7 +61,7 @@ ruleTester.run('header', rule, {
       options: [ licensePath ]
     },
     {
-      code: `${licenseText}\n\nmodule.exports = function() {};`,
+      code: `${licenseText}\n\n\n\n`,
       options: [ licensePath ]
     },
     {


### PR DESCRIPTION
Adds the ability to provide the license header as an array of lines instead of a file path. This is useful for monorepos where the lint script can run in many different locations and it is simply nicer to not have extra config files. 

```json
"license-header/header": ["error", ["/**", " * Copyright (c) Foo Corp.", " *", " * This source code is licensed under the WTFPL license found in the", " * LICENSE file in the root of this projects source tree.", " */"]]
```

I wasn't quite sure how to update the eslint plugin options schema, so I just removed it. If you could point me in the right direction on how to create the proper json schema type I would gladly add it back. 

I also added a script to fix eslint issues because I believe it is a good utility. 