### PR TITLE
Recognize `@license` annotated headers (SPDX headers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [eslint-plugin-license-header](https://github.com/nikku/e
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.7.0
+
+* `FEAT`: recognize `@license` annotated headers ([#19](https://github.com/nikku/eslint-plugin-license-header/issues/19))
+
 ## 0.6.1
 
 * `FIX`: play nicely with Svelte and Vue components ([#16](https://github.com/nikku/eslint-plugin-license-header/pull/16), [#6](https://github.com/nikku/eslint-plugin-license-header/issue/6))

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -98,7 +98,7 @@ module.exports = {
     }
 
     function isLicenseHeader(node) {
-      return node.value.includes('Copyright ');
+      return /(Copyright|@license)\b/i.test(node.value);
     }
 
     function hasValidText(comment) {

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -24,6 +24,15 @@ const licensePathWin = 'tests/fixtures/license-header-win.js';
 const arrayLicense = require('../../fixtures/license-header-array');
 const arrayLicenseText = arrayLicense.join('\n');
 
+// simple Apache-2.0 SPDX license header
+const spdxLicense = [
+  '/**',
+  ' * @license SPDX-License-Identifier: Apache-2.0',
+  ' */'
+];
+
+const spdxLicenseText = spdxLicense.join('\n');
+
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
@@ -68,6 +77,10 @@ ruleTester.run('header', rule, {
     {
       code: `${arrayLicenseText}\n\nmodule.exports = function() {};`,
       options: [ arrayLicense ]
+    },
+    {
+      code: `${spdxLicenseText}\n\nmodule.exports = function() {};`,
+      options: [ spdxLicense ]
     }
   ],
 


### PR DESCRIPTION
We previously only matched "license" headers that contained `Copyright`, now we match for headers that contain `@license` (such as short SPDX headers), too.

### Which issue does this PR address?

Closes https://github.com/nikku/eslint-plugin-license-header/issues/19
