### PR TITLE
Recognize `SPDX-License-Identifier` headers

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -98,7 +98,7 @@ module.exports = {
     }
 
     function isLicenseHeader(node) {
-      return /(Copyright|@license)\b/i.test(node.value);
+      return /(Copyright|@license|SPDX-License-Identifier)\b/i.test(node.value);
     }
 
     function hasValidText(comment) {

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -35,7 +35,7 @@ const spdxLicenseText = spdxLicense.join('\n');
 
 const spdxLicenseDoubleSlash = [
   '// SPDX-License-Identifier: Apache-2.0'
-]
+];
 
 const spdxLicenseDoubleSlashText = spdxLicenseDoubleSlash.join('\n');
 

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -33,6 +33,12 @@ const spdxLicense = [
 
 const spdxLicenseText = spdxLicense.join('\n');
 
+const spdxLicenseDoubleSlash = [
+  '// SPDX-License-Identifier: Apache-2.0'
+]
+
+const spdxLicenseDoubleSlashText = spdxLicenseDoubleSlash.join('\n');
+
 const singleLine = [
   '// Copyright Foobar. All Rights Reserved.'
 ];
@@ -87,6 +93,10 @@ ruleTester.run('header', rule, {
     {
       code: `${spdxLicenseText}\n\nmodule.exports = function() {};`,
       options: [ spdxLicense ]
+    },
+    {
+      code: `${spdxLicenseDoubleSlashText}\n\nmodule.exports = function() {};`,
+      options: [ spdxLicenseDoubleSlash ]
     },
     {
       code: `${singleLineText}\n\nmodule.exports = function() {};`,


### PR DESCRIPTION
This PR treats `SPDX-License-Identifier` comments as valid license headers.

### Which issue does this PR address?

Relaxes the check included in #20. See https://github.com/nikku/eslint-plugin-license-header/issues/19#issuecomment-2669602495
