### PR TITLE
feat: add optional second param, with allowedHeaderPatterns array of regex to match allowed headers

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -24,6 +24,20 @@ module.exports = {
         items: {
           type: 'string'
         }
+      },
+      {
+        type: 'object',
+        properties: {
+          allowedHeaderPatterns: {
+            type: 'array',
+            items: {
+
+              // Note: I wanted to use 'regex' instead of 'object' here.
+              type: [ 'object' ]
+            }
+          },
+        },
+        additionalProperties: false,
       }
     ]
   },
@@ -37,7 +51,8 @@ module.exports = {
     const separator = `${newlineChar}${newlineChar}`;
 
     const {
-      licenseHeader: rawHeader
+      licenseHeader: rawHeader,
+      allowedHeaderPatterns
     } = parseOptions(context);
 
     const licenseHeader = replaceNewlines(rawHeader, newlineChar);
@@ -76,7 +91,7 @@ module.exports = {
         options
       } = context;
 
-      const [ pathOrLicense ] = options;
+      const [ pathOrLicense, moreOpts ] = options;
 
       let licenseHeader;
 
@@ -88,8 +103,16 @@ module.exports = {
         licenseHeader = readLicenseFile(pathOrLicense).trim();
       }
 
+      // Optional `allowedHeaderPatterns` in second param. If provided, it is an
+      // array of license header patterns to accept as valid. Each entry is
+      // RegExp to match against the complete license header comment block.
+      // If no `allowedHeaderPatterns` are provided, the only valid license
+      // header is the `licenseHeader` string from the first param.
+      const allowedHeaderPatterns = moreOpts && moreOpts.allowedHeaderPatterns;
+
       return {
-        licenseHeader
+        licenseHeader,
+        allowedHeaderPatterns
       };
     }
 
@@ -102,7 +125,23 @@ module.exports = {
     }
 
     function hasValidText(comment) {
-      return sourceCode.getText(comment) === licenseHeader;
+      const text = sourceCode.getText(comment);
+      if (allowedHeaderPatterns) {
+        for (let pattern of allowedHeaderPatterns) {
+          if (typeof pattern === 'string') {
+            if (text === pattern) {
+              return true;
+            }
+          } else {
+            if (pattern.exec(text)) {
+              return true;
+            }
+          }
+        }
+        return false;
+      } else {
+        return text === licenseHeader;
+      }
     }
 
     function getLeadingComments(node) {

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -101,6 +101,27 @@ ruleTester.run('header', rule, {
     {
       code: `${singleLineText}\n\nmodule.exports = function() {};`,
       options: [ singleLine ]
+    },
+    {
+      code: `/**
+ * Copyright Foo Corp., Bar Corp.
+ * This is licensed under the WTFPL. See the LICENSE file.
+ */
+
+module.exports = function() {};`,
+      options: [
+        [
+          '/**',
+          ' * Copyright (c) Foo Corp.',
+          ' * This is licensed under the WTFPL. See the LICENSE file.',
+          ' */'
+        ],
+        {
+          allowedHeaderPatterns: [
+            /^\/\*\*\n \* Copyright Foo Corp.(, .+)*\n \* This is licensed under the WTFPL. See the LICENSE file.\n \*\/$/,
+          ]
+        }
+      ]
     }
   ],
 


### PR DESCRIPTION
Closes: #14

Thanks for this package! This PR implements one possible solution for #14. I'm happy to adjust as you see fit.

This adds an optional second config param, which is an object. Currently it adds one config option: `allowedHeaderPatterns`. This is an array of `RegExp`s to match against existing license header comment blocks to determine if the current license block is valid. If not provided it falls back to the current behaviour of requiring a match to the given `licenseHeader` in the first param.

# Checklist

- [ ] get feedback on general approach
- [ ] add docs
